### PR TITLE
fix removeNotRequiredBracesFrom to handle nested objects with empty strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,8 @@ module.exports = function extify () {
     });
 
     function removeNotRequiredBracesFrom(str) {
-        return str.replace(/('.*?[^\\]'|".*?[^\\]"|\/.*?[^\\]\/)/gm, '')
+        var result = str.replace(/(''|""|'.*?[^\\']'|".*?[^\\]"|\/.*?[^\\]\/)/gm, '');
+        return result;
     }
 
     function countChars(str, char) {

--- a/test/app/controller/Root.js
+++ b/test/app/controller/Root.js
@@ -9,6 +9,16 @@ Ext
         myOtherMixin: 'My.mixin.MyOtherMixin'
     },
 
+    _getCommonActions: function () {
+        var result = [
+            { popular: true, iconCls: '', text: 'A text', config: { type: 'text' } },
+            { popular: true, iconCls: 'icon-generic-newitem', text: 'New item menu', config: { type: 'newitem' } },
+            { popular: true, iconCls: '', text: 'Separator', config: { type: 'separator' } },
+            { popular: true, iconCls: 'icon-arrows-right', text: 'Right align', config: { type: 'right' } },
+            { popular: false, iconCls: 'icon-arrows-down', text: 'Menu list', config: { type: 'menulist' } },
+        ];
+        return result;
+    },
  
     isOdd: function(number) {
         return number % 2 === 1;


### PR DESCRIPTION
Input:
"{ foo: '', bar: { a: 'text' } }"

Observed: 
"{ foo: } }"

Expected:
{ foo: , bar: { a: } }

which is a problem for the comparison of opening and closing brackets.